### PR TITLE
updated the card component to fix overlapping heart bug on firefox

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -8,7 +8,7 @@ export default function Carad({ card, flipCard }) {
         style={{ transform: card.flipped ? "rotateY(180deg)" : null }}
       >
         <div className="card-back">{card.value}</div>
-        <div className="card-front">❤️</div>
+        {!card.flipped && <div className="card-front">❤️</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
only showing the card front when the card isn't flip. this solves the firefox rendering issue.
the bug has been seen in windows ff and android ff